### PR TITLE
Add patch-flutter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 Pinned version of Dart/Flutter used in Nubank. Should be used together.
 
-### `patch-flutter`
+### `flutter-patch`
 
 It is an alternative to `dart`/`flutter` above. This script patches a vanilla
 Flutter SDK installation. Just use it like this:
 
 ```shell
-patch-flutter $FLUTTER_ROOT
+flutter-patch $FLUTTER_ROOT
 ```
 
 Keep in mind that using this script is kind trick. That is because Flutter SDK

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@
 
 Pinned version of Dart/Flutter used in Nubank. Should be used together.
 
+### `patch-flutter`
+
+It is an alternative to `dart`/`flutter` above. This script patches a vanilla
+Flutter SDK installation. Just use it like this:
+
+```shell
+patch-flutter $FLUTTER_ROOT
+```
+
+Keep in mind that using this script is kind trick. That is because Flutter SDK
+downloads some binaries afterwards. Everytime Flutter downloads some binaries
+you need to rerun this script. You will see strange problems otherwise (i.e.:
+`flutter` commands failing to run or `no such file or directory` errors).
+
+So using `dart`/`flutter` packages is **recommended** and this script should
+be used as a last resort.
+
 ### `hover`
 
 [Hover](https://github.com/go-flutter-desktop/hover) allows running Flutter

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ in
   nubank = rec {
     dart = callPackage ./pkgs/dart {};
     flutter = callPackage ./pkgs/flutter {};
+    patch-flutter = callPackage ./pkgs/patch-flutter {};
     hover = callPackage ./pkgs/hover {
       inherit (super.xorg);
       go = pkgs.go;

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ in
   nubank = rec {
     dart = callPackage ./pkgs/dart {};
     flutter = callPackage ./pkgs/flutter {};
-    patch-flutter = callPackage ./pkgs/patch-flutter {};
+    flutter-patch = callPackage ./pkgs/flutter-patch {};
     hover = callPackage ./pkgs/hover {
       inherit (super.xorg);
       go = pkgs.go;

--- a/pkgs/flutter-patch/default.nix
+++ b/pkgs/flutter-patch/default.nix
@@ -1,13 +1,13 @@
 { pkgs, stdenv }:
 
 let
-  patchFlutter = pkgs.writeShellScriptBin "patch-flutter" ''
+  flutterPatch = pkgs.writeShellScriptBin "flutter-patch" ''
     usage() {
       cat <<EOT
     Patch vanilla Flutter SDK installation to work in NixOS.
 
     Usage:
-      patch-flutter FLUTTER_SDK_PATH
+      flutter-patch FLUTTER_SDK_PATH
     EOT
       exit 1
     }
@@ -24,7 +24,7 @@ let
 
     stopNest() { true; }
 
-    patchFlutterSdk() {
+    flutterPatchSdk() {
       source "${<nixpkgs/pkgs/build-support/setup-hooks/patch-shebangs.sh>}"
       patchShebangs --build "$1/bin/"
       find "$1/bin/" -executable -type f -exec "${pkgs.patchelf}/bin/patchelf" --set-interpreter "${pkgs.glibc}/lib/ld-linux-x86-64.so.2" {} \;
@@ -34,11 +34,11 @@ let
       usage
     fi
 
-    patchFlutterSdk "$@"
+    flutterPatchSdk "$@"
   '';
 in
 stdenv.mkDerivation {
-  name = "patch-flutter";
+  name = "flutter-patch";
   unpackPhase = "true";
 
   meta = with stdenv.lib; {
@@ -48,8 +48,8 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -r ${patchFlutter}/bin $out
+    cp -r ${flutterPatch}/bin $out
   '';
 
-  buildInputs = [ patchFlutter ];
+  buildInputs = [ flutterPatch ];
 }

--- a/pkgs/patch-flutter/default.nix
+++ b/pkgs/patch-flutter/default.nix
@@ -1,0 +1,55 @@
+{ pkgs, stdenv }:
+
+let
+  patchFlutter = pkgs.writeShellScriptBin "patch-flutter" ''
+    usage() {
+      cat <<EOT
+    Patch vanilla Flutter SDK installation to work in NixOS.
+
+    Usage:
+      patch-flutter FLUTTER_SDK_PATH
+    EOT
+      exit 1
+    }
+
+    isScript() {
+        local fn="$1"
+        local fd
+        local magic
+        exec {fd}< "$fn"
+        read -r -n 2 -u "$fd" magic
+        exec {fd}<&-
+        if [[ "$magic" =~ \#! ]]; then return 0; else return 1; fi
+    }
+
+    stopNest() { true; }
+
+    patchFlutterSdk() {
+      source "${<nixpkgs/pkgs/build-support/setup-hooks/patch-shebangs.sh>}"
+      patchShebangs --build "$1/bin/"
+      find "$1/bin/" -executable -type f -exec "${pkgs.patchelf}/bin/patchelf" --set-interpreter "${pkgs.glibc}/lib/ld-linux-x86-64.so.2" {} \;
+    }
+
+    if [ "$#" -lt 1 ]; then
+      usage
+    fi
+
+    patchFlutterSdk "$@"
+  '';
+in
+stdenv.mkDerivation {
+  name = "patch-flutter";
+  unpackPhase = "true";
+
+  meta = with stdenv.lib; {
+    description =
+      "Script to patch a vanilla Flutter SDK installation to work in NixOS.";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r ${patchFlutter}/bin $out
+  '';
+
+  buildInputs = [ patchFlutter ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -7,8 +7,9 @@ with pkgs;
 pkgs.mkShell {
   buildInputs = [
     # You can comment some derivations here to test only one package
-    # nubank.dart
-    # nubank.flutter
+    nubank.dart
+    nubank.flutter
     nubank.hover
+    nubank.patch-flutter
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,6 @@ pkgs.mkShell {
     nubank.dart
     nubank.flutter
     nubank.hover
-    nubank.patch-flutter
+    nubank.flutter-patch
   ];
 }


### PR DESCRIPTION
The idea is to be used as a fallback in case `flutter` or `dart` doesn't work.

This script patches the official binaries from Flutter SDK. It is kinda messy to use (since `flutter` command downloads the binaries in the first run, and also there is some binaries downloaded only after a project setup, so you need to run this command twice), but it works.