### PR TITLE
Fix hover

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,8 @@ self: super:
 let
   pkgs = super.pkgs;
   callPackage = super.lib.callPackageWith super;
-in {
+in
+{
   nubank = rec {
     dart = callPackage ./pkgs/dart {};
     flutter = callPackage ./pkgs/flutter {};

--- a/pkgs/dart/dart.nix
+++ b/pkgs/dart/dart.nix
@@ -6,53 +6,54 @@ let
 
   sources = let
     base = "https://storage.googleapis.com/dart-archive/channels";
-  in {
-    "${version}-x86_64-linux" = fetchurl {
-      url = "${base}/${channel}/release/${version}/sdk/dartsdk-linux-x64-release.zip";
-      sha256 = sha256Hash;
+  in
+    {
+      "${version}-x86_64-linux" = fetchurl {
+        url = "${base}/${channel}/release/${version}/sdk/dartsdk-linux-x64-release.zip";
+        sha256 = sha256Hash;
+      };
     };
-  };
 
 in
 
-with stdenv.lib;
+  with stdenv.lib;
 
-stdenv.mkDerivation {
+  stdenv.mkDerivation {
 
-  pname = "dart";
-  inherit version;
+    pname = "dart";
+    inherit version;
 
-  nativeBuildInputs = [
-    unzip
-  ];
+    nativeBuildInputs = [
+      unzip
+    ];
 
-  src = sources."${version}-${stdenv.hostPlatform.system}" or (throw "unsupported version/system: ${version}/${stdenv.hostPlatform.system}");
+    src = sources."${version}-${stdenv.hostPlatform.system}" or (throw "unsupported version/system: ${version}/${stdenv.hostPlatform.system}");
 
-  installPhase = ''
-    mkdir -p $out
-    cp -R * $out/
-    echo $libPath
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-             --set-rpath $libPath \
-             $out/bin/dart
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-             --set-rpath $libPath \
-             $out/bin/dartaotruntime
-  '';
-
-  libPath = makeLibraryPath [ stdenv.cc.cc ];
-
-  dontStrip = true;
-
-  meta = {
-    homepage = "https://www.dartlang.org/";
-    description = "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
-    longDescription = ''
-      Dart is a class-based, single inheritance, object-oriented language
-      with C-style syntax. It offers compilation to JavaScript, interfaces,
-      mixins, abstract classes, reified generics, and optional typing.
+    installPhase = ''
+      mkdir -p $out
+      cp -R * $out/
+      echo $libPath
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+               --set-rpath $libPath \
+               $out/bin/dart
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+               --set-rpath $libPath \
+               $out/bin/dartaotruntime
     '';
-    platforms = [ "x86_64-linux" ];
-    license = licenses.bsd3;
-  };
-}
+
+    libPath = makeLibraryPath [ stdenv.cc.cc ];
+
+    dontStrip = true;
+
+    meta = {
+      homepage = "https://www.dartlang.org/";
+      description = "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
+      longDescription = ''
+        Dart is a class-based, single inheritance, object-oriented language
+        with C-style syntax. It offers compilation to JavaScript, interfaces,
+        mixins, abstract classes, reified generics, and optional typing.
+      '';
+      platforms = [ "x86_64-linux" ];
+      license = licenses.bsd3;
+    };
+  }

--- a/pkgs/dart/default.nix
+++ b/pkgs/dart/default.nix
@@ -1,8 +1,9 @@
 { pkgs }:
 
 let
-  mkDart = opts: pkgs.callPackage (import ./dart.nix opts) { };
-in mkDart {
+  mkDart = opts: pkgs.callPackage (import ./dart.nix opts) {};
+in
+mkDart {
   channel = "stable";
   version = "2.9.1";
   sha256Hash = "1v8fisjp948r0xp9zakiiz6j0flpnzin4jgl1blingif902j22cf";

--- a/pkgs/flutter/default.nix
+++ b/pkgs/flutter/default.nix
@@ -1,8 +1,9 @@
 { pkgs }:
 
 let
-  mkFlutter = opts: pkgs.callPackage (import ./flutter.nix opts) { };
-in mkFlutter rec {
+  mkFlutter = opts: pkgs.callPackage (import ./flutter.nix opts) {};
+in
+mkFlutter rec {
   pname = "flutter";
   channel = "stable";
   version = "1.20.2";

--- a/pkgs/flutter/flutter.nix
+++ b/pkgs/flutter/flutter.nix
@@ -1,9 +1,36 @@
-{ channel, pname, version, sha256Hash, patches
-, filename ? "flutter_linux_v${version}-${channel}.tar.xz" }:
+{ channel
+, pname
+, version
+, sha256Hash
+, patches
+, filename ? "flutter_linux_v${version}-${channel}.tar.xz"
+}:
 
-{ bash, buildFHSUserEnv, cacert, coreutils, git, makeWrapper, runCommand, stdenv
-, fetchurl, alsaLib, dbus, expat, libpulseaudio, libuuid, libX11, libxcb
-, libXcomposite, libXcursor, libXdamage, libXfixes, libGL, nspr, nss, systemd }:
+{ bash
+, buildFHSUserEnv
+, cacert
+, coreutils
+, git
+, makeWrapper
+, runCommand
+, stdenv
+, fetchurl
+, alsaLib
+, dbus
+, expat
+, libpulseaudio
+, libuuid
+, libX11
+, libxcb
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXfixes
+, libGL
+, nspr
+, nss
+, systemd
+}:
 
 let
   drvName = "flutter-${channel}-${version}";
@@ -62,10 +89,12 @@ let
     name = "${drvName}-fhs-env";
     multiPkgs = pkgs: [
       # Flutter only use these certificates
-      (runCommand "fedoracert" { } ''
-        mkdir -p $out/etc/pki/tls/
-        ln -s ${cacert}/etc/ssl/certs $out/etc/pki/tls/certs
-      '')
+      (
+        runCommand "fedoracert" {} ''
+          mkdir -p $out/etc/pki/tls/
+          ln -s ${cacert}/etc/ssl/certs $out/etc/pki/tls/certs
+        ''
+      )
       pkgs.zlib
     ];
     targetPkgs = pkgs:
@@ -99,7 +128,8 @@ let
       ];
   };
 
-in runCommand drvName {
+in
+runCommand drvName {
   startScript = ''
     #!${bash}/bin/bash
     export PUB_CACHE=''${PUB_CACHE:-"$HOME/.pub-cache"}

--- a/pkgs/hover/default.nix
+++ b/pkgs/hover/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildGoModule
 , buildFHSUserEnv
-, corefonts
+, dejavu_fonts
 , pkgconfig
 , fetchFromGitHub
 , stdenv
@@ -86,7 +86,7 @@ in
 buildFHSUserEnv rec {
   name = pname;
   targetPkgs = pkgs: [
-    corefonts
+    dejavu_fonts
     flutter
     gcc
     go

--- a/pkgs/hover/default.nix
+++ b/pkgs/hover/default.nix
@@ -1,6 +1,18 @@
-{ lib, buildGoModule, buildFHSUserEnv, pkgconfig, fetchFromGitHub,
-stdenv, writeScript, xorg, libglvnd, addOpenGLRunpath, makeWrapper,
-gcc, go, flutter }:
+{ lib
+, buildGoModule
+, buildFHSUserEnv
+, pkgconfig
+, fetchFromGitHub
+, stdenv
+, writeScript
+, xorg
+, libglvnd
+, addOpenGLRunpath
+, makeWrapper
+, gcc
+, go
+, flutter
+}:
 
 let
   pname = "hover";
@@ -68,7 +80,8 @@ let
     '';
   };
 
-in buildFHSUserEnv rec {
+in
+buildFHSUserEnv rec {
   name = pname;
   targetPkgs = pkgs: [
     flutter

--- a/pkgs/hover/default.nix
+++ b/pkgs/hover/default.nix
@@ -1,81 +1,82 @@
 { lib, buildGoModule, buildFHSUserEnv, pkgconfig, fetchFromGitHub,
-  stdenv, writeScript, xorg, libglvnd, addOpenGLRunpath, makeWrapper,
-  gcc, go, flutter }:
+stdenv, writeScript, xorg, libglvnd, addOpenGLRunpath, makeWrapper,
+gcc, go, flutter }:
 
 let
   pname = "hover";
   version = "0.43.0";
 
   libs = with xorg; [
-    libXi
-    libXxf86vm
-    libglvnd.dev
     libX11.dev
     libXcursor.dev
+    libXext.dev
+    libXi.dev
     libXinerama.dev
     libXrandr.dev
     libXrender.dev
+    libXfixes.dev
+    libXxf86vm
+    libglvnd.dev
     xorgproto
   ];
-in buildGoModule rec {
-  inherit pname version;
+  hover = buildGoModule rec {
+    inherit pname version;
 
-  meta = with stdenv.lib; {
-    description = "A build tool to run Flutter applications on desktop";
-    homepage = "https://github.com/go-flutter-desktop/hover";
-    license = licenses.bsd3;
-    platforms = platforms.linux ++ platforms.darwin;
+    meta = with stdenv.lib; {
+      description = "A build tool to run Flutter applications on desktop";
+      homepage = "https://github.com/go-flutter-desktop/hover";
+      license = licenses.bsd3;
+      platforms = platforms.linux ++ platforms.darwin;
+    };
+
+    subPackages = [ "." ];
+
+    vendorSha256 = "1wr08phjm87dxim47i8449rmq5wfscvjyz65g3lxmv468x209pam";
+
+    src = fetchFromGitHub {
+      rev = "v${version}";
+      owner = "go-flutter-desktop";
+      repo = pname;
+      sha256 = "0iw6sxg86wfdbihl2hxzn43ppdzl1p7g5b9wl8ac3xa9ix8759ax";
+    };
+
+    nativeBuildInputs = [ addOpenGLRunpath makeWrapper ];
+
+    buildInputs = libs;
+
+    checkRun = false;
+
+    patches = [
+      ./fix-assets-path.patch
+    ];
+
+    postPatch = ''
+      sed -i 's|@assetsFolder@|'"''${out}/share/assets"'|g' internal/fileutils/assets.go
+    '';
+
+    postInstall = ''
+      mkdir -p $out/share
+      cp -r assets $out/share/assets
+      chmod -R a+rx $out/share/assets
+
+      wrapProgram "$out/bin/hover" \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath libs}
+    '';
+
+    postFixup = ''
+      addOpenGLRunpath $out/bin/hover
+    '';
   };
 
-  subPackages = [ "." ];
-
-  vendorSha256 = "1wr08phjm87dxim47i8449rmq5wfscvjyz65g3lxmv468x209pam";
-
-  src = fetchFromGitHub {
-    rev = "v${version}";
-    owner = "go-flutter-desktop";
-    repo = pname;
-    sha256 = "0iw6sxg86wfdbihl2hxzn43ppdzl1p7g5b9wl8ac3xa9ix8759ax";
-  };
-
-  nativeBuildInputs = [ addOpenGLRunpath makeWrapper ];
-
-  propagatedBuildInputs = [
+in buildFHSUserEnv rec {
+  name = pname;
+  targetPkgs = pkgs: [
     flutter
     gcc
     go
+    hover
     pkgconfig
   ] ++ libs;
 
-  checkRun = false;
-
-  patches = [
-    ./fix-assets-path.patch
-  ];
-
-  postPatch = ''
-    sed -i 's|@assetsFolder@|'"''${out}/share/assets"'|g' internal/fileutils/assets.go
-  '';
-
-  postInstall = ''
-    mkdir -p $out/share
-    cp -r assets $out/share/assets
-    chmod -R a+rx $out/share/assets
-
-    wrapProgram "$out/bin/hover" \
-      --prefix CPATH : ${xorg.libX11.dev}/include:${xorg.libXcursor.dev}/include:${xorg.libXi.dev}/include:${xorg.libXinerama.dev}/include:${xorg.libXrandr.dev}/include:${xorg.libXxf86vm.dev}/include:${xorg.libXext.dev}/include \
-      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [
-        xorg.libX11
-        xorg.libXcursor
-        xorg.libXi
-        xorg.libXinerama
-        xorg.libXrandr
-        xorg.libXxf86vm
-        xorg.libXext
-      ]}
-  '';
-
-  postFixup = ''
-    addOpenGLRunpath $out/bin/hover
-  '';
+  runScript = "hover";
 }

--- a/pkgs/hover/default.nix
+++ b/pkgs/hover/default.nix
@@ -1,9 +1,11 @@
 { lib
 , buildGoModule
 , buildFHSUserEnv
+, corefonts
 , pkgconfig
 , fetchFromGitHub
 , stdenv
+, roboto
 , writeScript
 , xorg
 , libglvnd
@@ -84,11 +86,13 @@ in
 buildFHSUserEnv rec {
   name = pname;
   targetPkgs = pkgs: [
+    corefonts
     flutter
     gcc
     go
     hover
     pkgconfig
+    roboto
   ] ++ libs;
 
   runScript = "hover";


### PR DESCRIPTION
Based on this PR: NixOS/nixpkgs#80075

I exported the `go` and `gcc` packages so it was available inside the FHS env and also fixed the X11 libraries, and this seems to do the trick.

There is no more reason to wrapper with `CPATH`, and the only reason we keep `LD_LIBRARY_PATH` is because hover is built outside the `buildFHSUserEnv` so it wouldn't found the libraries otherwise.

Tested on both `nix-shell --pure` and also in `environment.systemPackages`. I recommend the reviewer to remove `GOCACHE` (`rm -rf $(go env GOCACHE)`) before testing.