### PR TITLE
Use mkFlutter from nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,12 +3,21 @@ let
   pkgs = super.pkgs;
   callPackage = super.lib.callPackageWith super;
   nodejsNubank = pkgs.nodejs-10_x;
+  nixpkgs = import (import ./pkgs/nixpkgs-src.nix {
+    fakeSha256 = super.stdenv.lib.fakeSha256;
+  }) {
+    config = {};
+    overlays = [];
+  };
 in
 {
   nubank = rec {
     dart = callPackage ./pkgs/dart {};
 
-    flutter = callPackage ./pkgs/flutter {};
+    flutter = callPackage ./pkgs/flutter {
+      flutterPackages = nixpkgs.flutterPackages;
+      dart = dart;
+    };
 
     flutter-patch = callPackage ./pkgs/flutter-patch {};
 

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ let
   pkgs = super.pkgs;
   callPackage = super.lib.callPackageWith super;
   nodejsNubank = pkgs.nodejs-10_x;
-  nixpkgs = import (import ./pkgs/nixpkgs-src.nix {
+  unstable = import (import ./pkgs/nixpkgs-src.nix {
     fakeSha256 = super.stdenv.lib.fakeSha256;
   }) {
     config = {};
@@ -15,7 +15,7 @@ in
     dart = callPackage ./pkgs/dart {};
 
     flutter = callPackage ./pkgs/flutter {
-      flutterPackages = nixpkgs.flutterPackages;
+      flutterPackages = unstable.flutterPackages;
       dart = dart;
     };
 
@@ -35,20 +35,9 @@ in
       nssTools
       openssl
       python37Full
+      unstable.openfortivpn
       # TODO: ruby is installed by Ansible, but I never saw it used in Nubank
       # ruby
-      (openfortivpn.overrideAttrs (old: rec {
-        repo = "openfortivpn";
-        version = "1.15.0";
-        name = "${repo}-${version}";
-
-        src = fetchFromGitHub {
-          owner = "adrienverge";
-          inherit repo;
-          rev = "v${version}";
-          sha256 = "1qsfgpxg553s8rc9cyrc4k96z0pislxsdxb9wyhp8fdprkak2mw2";
-        };
-      }))
       (yarn.override ({ nodejs = nodejsNubank; }))
     ];
 

--- a/pkgs/flutter/default.nix
+++ b/pkgs/flutter/default.nix
@@ -1,6 +1,9 @@
-{ flutterPackages }:
+{ flutterPackages, dart }:
 
-flutterPackages.mkFlutter rec {
+let
+  # Avoid infinite recursion here
+  myDart = dart;
+in flutterPackages.mkFlutter rec {
   pname = "flutter";
   channel = "stable";
   version = "1.22.2";
@@ -10,4 +13,5 @@ flutterPackages.mkFlutter rec {
     ./disable-auto-update.patch
     ./move-cache.patch
   ];
+  dart = myDart;
 }

--- a/pkgs/nixpkgs-src.nix
+++ b/pkgs/nixpkgs-src.nix
@@ -1,8 +1,8 @@
 { fakeSha256 }:
 
 builtins.fetchTarball {
-    url = "https://github.com/nixos/nixpkgs/tarball/bee3fb885fa3476fc6cd5274b1600f80bc278e51";
+    url = "https://github.com/nixos/nixpkgs/tarball/fef46b9281cfde685bfdea74572eae34b518d48e";
     # Use fakeSha256 to generate a new sha256 when updating, i.e.:
     # sha256 = fakeSha256;
-    sha256 = "0iza3wfmz6lwiw8n9hzp75mxfsklq2pa9y3pvyxycnqs2i42sxdp";
+    sha256 = "1cjn0i8zy145i2whdjxgk67smbh6jiq0snxps8cp061511vp3gz3";
 }

--- a/pkgs/nixpkgs-src.nix
+++ b/pkgs/nixpkgs-src.nix
@@ -1,0 +1,8 @@
+{ fakeSha256 }:
+
+builtins.fetchTarball {
+    url = "https://github.com/nixos/nixpkgs/tarball/bee3fb885fa3476fc6cd5274b1600f80bc278e51";
+    # Use fakeSha256 to generate a new sha256 when updating, i.e.:
+    # sha256 = fakeSha256;
+    sha256 = "0iza3wfmz6lwiw8n9hzp75mxfsklq2pa9y3pvyxycnqs2i42sxdp";
+}


### PR DESCRIPTION
This should fix the Flutter build in `unstable`, and make sure that everyone using this repository should build Flutter (even if someone is still using old releases).

Also, remove the old manual backport of `openfortivpn`, prefering using the recipe from `unstable` instead.

Substitute PR: https://github.com/nubank/nixpkgs/pull/17