### PR TITLE
flutter: 1.22.5 -> 1.22.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,10 +3,10 @@ let
   unstable = import (builtins.fetchTarball {
     # When bumping, use the last commit from https://github.com/NixOS/nixpkgs/tree/nixpkgs-unstable
     # So we can use Hydra cache when possible
-    url = "https://github.com/nixos/nixpkgs/archive/4c9a74aa459dc525fcfdfb3019b234f68de66c8a.tar.gz";
+    url = "https://github.com/nixos/nixpkgs/archive/f5daa8ab31fb910712b3e1e71ae46818bc9e33b3.tar.gz";
     # Use fakeSha256 to generate a new sha256 when updating, i.e.:
     # sha256 = super.stdenv.lib.fakeSha256;
-    sha256 = "1wl1q3lqgn3lx3chil59l06pimh9by0bx16h9rk6nfmk6shhwrbw";
+    sha256 = "0sa96nmbs37fix7xxxzj3dmryi515arnzicfg71qhkp45gn44dzq";
   }) {};
   callPackage = unstable.pkgs.callPackage;
 in

--- a/pkgs/flutter/default.nix
+++ b/pkgs/flutter/default.nix
@@ -1,7 +1,7 @@
 { flutterPackages, fetchurl, dart }:
 
 let
-  version = "1.22.5";
+  version = "1.22.4";
   channel = "stable";
   filename = "flutter_linux_${version}-${channel}.tar.xz";
 in flutterPackages.mkFlutter rec {
@@ -9,9 +9,8 @@ in flutterPackages.mkFlutter rec {
   pname = "flutter";
   src = fetchurl {
     url = "https://storage.googleapis.com/flutter_infra/releases/${channel}/linux/${filename}";
-    sha256 = "1dv5kczcj9npf7xxlanmpc9ijnxa3ap46521cxn14c0i3y9295ja";
+    sha256 = "0qalgav9drqddcj8lfvl9ddf3325n953pvkmgha47lslg9sa88zw";
   };
-  depsSha256 = "0d7vhk6axgqajy2d9ia9lc6awcnz6cc3n04r7hnh7bx4hb0jv0l1";
   patches = [
     ./disable-auto-update.patch
     ./move-cache.patch


### PR DESCRIPTION
Until we fix an issue with Flutter 1.22.5 we need to keep the older version.