### PR TITLE
Use specific dart version for flutter

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ let
 
   inherit (unstable.pkgs) callPackage;
 
-  dart = unstable.dart;
+  dart = callPackage ./pkgs/dart { inherit unstable; };
 
   flutter = callPackage ./pkgs/flutter { inherit (final.nubank) dart; };
 

--- a/pkgs/dart/default.nix
+++ b/pkgs/dart/default.nix
@@ -1,0 +1,30 @@
+{ unstable, fetchurl }:
+
+let
+  version = "2.13.1";
+  base = "https://storage.googleapis.com/dart-archive/channels";
+  x86_64 = "x64";
+  i686 = "ia32";
+  aarch64 = "arm64";
+
+  sources = {
+    "${version}-x86_64-darwin" = fetchurl {
+      url = "${base}/stable/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
+      sha256 = "0kb6r2rmp5d0shvgyy37fmykbgww8qaj4f8k79rmqfv5lwa3izya";
+    };
+    "${version}-x86_64-linux" = fetchurl {
+      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
+      sha256 = "0zq8wngyrw01wjc5s6w1vz2jndms09ifiymjjixxby9k41mr6jrq";
+    };
+    "${version}-i686-linux" = fetchurl {
+      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
+      sha256 = "0zv4q8xv2i08a6izpyhhnil75qhs40m5mgyvjqjsswqkwqdf7lkj";
+    };
+    "${version}-aarch64-linux" = fetchurl {
+      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
+      sha256 = "0bb9jdmg5p608jmmiqibp13ydiw9avgysxlmljvgsl7wl93j6rgc";
+    };
+  };
+in unstable.dart.override {
+  inherit version sources;
+}


### PR DESCRIPTION
The flutter version we use in prod is 2.2.1 with dart version of 2.13.1, since we were not using a specific dart version at nix overlay, we ended up using dart unstable version 2.14.1 which doesn't work with our flutter version